### PR TITLE
Fix hashbang

### DIFF
--- a/ical2org.awk
+++ b/ical2org.awk
@@ -1,4 +1,4 @@
-#!/usr/bin/env gawk -f
+#!/usr/bin/env -S gawk -f
 # awk script for converting an iCal formatted file to a sequence of org-mode headings.
 # this may not work in general but seems to work for day and timed events from Google's
 # calendar, which is really all I need right now...


### PR DESCRIPTION
`env` requires `-S` to run commands with arguments.