### PR TITLE
Change the title of the converted calendar with environments

### DIFF
--- a/ical2org.awk
+++ b/ical2org.awk
@@ -102,6 +102,9 @@ BEGIN {
     # and to your email address
     emailaddress = ENVIRON["EMAIL"] != "" ? ENVIRON["EMAIL"] : "unknown"
 
+    # main title of the Org file
+    title = ENVIRON["TITLE"] != "" ? ENVIRON["TITLE"] : "Main Google calendar entries"
+
     # calendar/category name for display in org-mode
     calendarname = ENVIRON["CALENDAR"] != "" ? ENVIRON["CALENDAR"] : "unknown"
 
@@ -125,7 +128,7 @@ BEGIN {
     max_age_seconds = max_age*24*60*60
 
     if (header) {
-        print "#+TITLE:       Main Google calendar entries"
+        print "#+TITLE:      ", title
         print "#+AUTHOR:     ", author
         print "#+EMAIL:      ", emailaddress
         print "#+DESCRIPTION: converted using the ical2org awk script"


### PR DESCRIPTION
Each converted ical file is hard-coded to have the same title "Main Google
calendar entries" in the Org file property header. All other properties can be
set by declaring an environment before running the script. This pull request
brings that option to the `#+TITLE` property as well.